### PR TITLE
Add Usage section to README (and link to Nested Elements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can install Export Sheet Data [here](https://chrome.google.com/webstore/deta
 How to use
 ----------
 
-Currently the best way to figure out how to use ESD is by opening the sidebar, reading the toolbars of various options and experimenting with the output using the Visualize option.
+Currently the best way to figure out how to use ESD is by opening the sidebar, reading the tooltips of various options and experimenting with the output using the Visualize option.
 
 If you want to create more advanced data structures, make sure to read the Wiki page about [Nested Elements](https://github.com/Synthoid/ExportSheetData/wiki/Nested-Elements).
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@ Goals
 
 **Customizable:** Options and formats can be tweaked to reflect personal taste. Newline or sameline braces for JSON. Attributes or child elements for XML. Format your data the way you want.
 
-
-
 Install
 -------
 You can install Export Sheet Data [here](https://chrome.google.com/webstore/detail/export-sheet-data/bfdcopkbamihhchdnjghdknibmcnfplk?utm_source=permalink)
+
+How to use
+----------
+
+Currently the best way to figure out how to use ESD is by opening the sidebar, reading the toolbars of various options and experimenting with the output using the Visualize option.
+
+If you want to create more advanced data structures, make sure to read the Wiki page about [Nested Elements](https://github.com/Synthoid/ExportSheetData/wiki/Nested-Elements).
 
 Development Status
 ------------------


### PR DESCRIPTION
Since the Github repo is the canonical URL of the project, I thought it would be good to have a link in the README.

On this note, maybe a bit more info on usage would be useful as it took me a while to figure out options through experimentation. I was going to propose some changes to the docs in the Wiki (like embedding the Nested Elements example spreadsheets alongside their JSON output), but unfortunately I don't think it's possible to create a pull request with Wiki changes. So maybe a good way forward for documentation would be to move it from the Wiki to the repo (e.g. a `/docs` folder) to open it up for community contributions.